### PR TITLE
Remove link to 3v4l

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -30,10 +30,6 @@
   href: http://webchat.freenode.net/?channels=hhvm
   category: external
 
-- title: 3v4l
-  href: http://3v4l.org/
-  category: external
-
 - title: Module Support
   href: http://hhvm.h4cc.de/
   category: external


### PR DESCRIPTION
3v4l stopped allowing you to execute on hhvm in October of last year.