### PR TITLE
Remove trailing slash from Slack invite

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -23,7 +23,7 @@
   category: external
 
 - title: Slack
-  href: /slack/
+  href: /slack
   category: external
 
 - title: Twitter


### PR DESCRIPTION
https://hhvm.com/slack/ is a 404. Removing the slash from the url redirects correctly.