### PR TITLE
Fix typos in recent blog posts

### DIFF
--- a/_posts/2020-03-03-hhvm-4.47.markdown
+++ b/_posts/2020-03-03-hhvm-4.47.markdown
@@ -37,7 +37,7 @@ HHVM 4.42&ndash;4.46 remain supported, as do the 4.8 and 4.32 LTS releases.
 # Breaking Changes
 
 - Trying to declare a function, constant, or enum type with the same name as a
-  preceeding `use function`, `use const`, or `use type` declaration is now a
+  preceding `use function`, `use const`, or `use type` declaration is now a
   parser error.
   - It had already been a runtime error.
   - This makes the behavior consistent with classes, where it was already a

--- a/_posts/2020-03-09-hhvm-4.48.markdown
+++ b/_posts/2020-03-09-hhvm-4.48.markdown
@@ -23,7 +23,7 @@ HHVM 4.43&ndash;4.47 remain supported, as do the 4.8 and 4.32 LTS releases.
   or protected", previously (incorrectly) "Access type [...] must be omitted".
 - `hh_client lsp --config` now accepts `.hhconfig` settings, in addition to
   `hh.conf` (system-wide) settings.
-- Error for unitialized members now suggest making the property "nullable"
+- Error for uninitialized members now suggest making the property "nullable"
   instead of "optional", to avoid confusion with shape terminology.
 - Suggest using `$x is SomeEnum` if an exhaustive switch statement contains a
   `default:` block.

--- a/_posts/2020-05-04-hhvm-4.56.markdown
+++ b/_posts/2020-05-04-hhvm-4.56.markdown
@@ -73,4 +73,4 @@ include GCC6 or below:
 - Ubuntu 16.04 (Xenial)
 
 Other unsupported distributions may be removed from future releases without
-futher notice.
+further notice.

--- a/_posts/2020-06-24-skipping-hhvm-4.63.markdown
+++ b/_posts/2020-06-24-skipping-hhvm-4.63.markdown
@@ -27,7 +27,7 @@ legacy (PHP-style) arrays.
 - The INI flag `hhvm.hack_arr_compat_specialization` will be removed and its
   behavior will be enabled by default. We highly recommend enabling this flag in
   your current HHVM release before upgrading to HHVM 4.64.
-  This change disables the implicit inter-operability between `varray`s and
+  This change disables the implicit interoperability between `varray`s and
   `darray`s. Instead, `varray` and `darray` will be treated
   as types in their own right. Specifically:
   * Using a `varray` where a `darray` is expected (at parameter and return value

--- a/_posts/2020-06-30-hhvm-4.64.markdown
+++ b/_posts/2020-06-30-hhvm-4.64.markdown
@@ -13,7 +13,7 @@ and 4.56 LTS releases.
 
 - The INI flag `hhvm.hack_arr_compat_specialization` was removed and its
   behavior is now enabled by default.
-  This change disables the implicit inter-operability between `varray`s and
+  This change disables the implicit interoperability between `varray`s and
   `darray`s. Instead, `array` (soon to be removed), `varray` and `darray` are
   now treated as types in their own right. Specifically:
   * Using a `varray` where a `darray` is expected (at parameter and return value

--- a/_posts/2020-09-02-XHP-namespaces-and-syntax.md
+++ b/_posts/2020-09-02-XHP-namespaces-and-syntax.md
@@ -20,7 +20,7 @@ XHP v4 includes several changes to:
   broader use of XHP in new contexts.
 - be consistent with other modern Hack libraries, especially the HSL.
 
-We expect future development of XHP to be focussed on making XHP more consistent
+We expect future development of XHP to be focused on making XHP more consistent
 with the rest of Hack, especially from a type system perspective.
 
 # Overview

--- a/_posts/2021-01-12-hhvm-4.92.markdown
+++ b/_posts/2021-01-12-hhvm-4.92.markdown
@@ -28,7 +28,7 @@ HHVM 4.84&ndash;4.91 remain supported, as do the 4.56 and 4.80 LTS releases.
   not been kept up to date or correct, and was not exposed to the typechecker.
 - `apc_cache_info()` now correctly returns an `uncounted_entries` key instead of
   `uncounted_entires`.
-- Calling methods on `dynamic` values requires that all values are coercable to
+- Calling methods on `dynamic` values requires that all values are coercible to
   `dynamic`, and the return type will be `dynamic`.
 - it is now a syntax error to declare a function as `async` without an
   `Awaitable` return type; previously this was separately checked by the type

--- a/_posts/2021-02-01-hhvm-4.95.markdown
+++ b/_posts/2021-02-01-hhvm-4.95.markdown
@@ -15,7 +15,7 @@ HHVM 4.88&ndash;4.94 remain supported, as do the 4.56 and 4.80 LTS releases.
 - Fixed an issue where overriding a type constant from a parent class/interface
   could cause a runtime error even if the code passed the typechecker
   ([example](https://github.com/facebook/hhvm/commit/206760e532d7f58084d9f32904d35b6735f57e66#diff-980a17de858c05e56fd438cc18277928d6403d191640f53d25c0302af056b22d)).
-- Fixed various typechecker error messages incorrectly refering to a type
+- Fixed various typechecker error messages incorrectly referring to a type
   constant as "property".
 - The SOAP extension now supports proxy authentication (new options
   `proxy_ssl_cert_path`, `proxy_ssl_key_path`, `proxy_ssl_ca_bundle`).

--- a/_posts/2021-04-14-hhvm-4.105.markdown
+++ b/_posts/2021-04-14-hhvm-4.105.markdown
@@ -23,7 +23,7 @@ HHVM 4.100&ndash;4.104 remain supported, as does the 4.80 LTS release.
   `sharedmem_compression` `.hhconfig` option to a ZSTD compression level; 3
   is ZSTD's default. This is essentially CPU vs memory tradeoff - large
   projects may wish to experiment with this option.
-- interface type constants can now be overriden by implementing classes.
+- interface type constants can now be overridden by implementing classes.
 
 # Breaking Changes
 

--- a/_posts/2021-05-11-hhvm-4.109.markdown
+++ b/_posts/2021-05-11-hhvm-4.109.markdown
@@ -52,7 +52,7 @@ HHVM 4.104&ndash;4.108 remain supported, as do the 4.80 and 4.102 LTS releases.
 
 # Watchman-based Built-In Autoloading
 
-Built-in autoloading is now avaiable, but depends on the
+Built-in autoloading is now available, but depends on the
 [Watchman](https://github.com/facebook/watchman/) daemon being installed
 on your system.
 


### PR DESCRIPTION
Make spelling of "focused" american and match earlier posts such as _posts/2019-05-13-hhvm-4.5.0.markdown