### PR TITLE
Announce 4.125

### DIFF
--- a/_posts/2021-08-25-hhvm-4.125.markdown
+++ b/_posts/2021-08-25-hhvm-4.125.markdown
@@ -1,0 +1,17 @@
+---
+title: "HHVM 4.124"
+layout: post
+author: fred
+category: blog
+---
+
+HHVM 4.124 is released! This release marks the end of support for 4.118; HHVM 4.120&ndash;4.123 remain supported (4.119 was skipped), as do the 4.80 and 4.102 LTS releases.
+
+This release primarily contains improvements to implementation details, and
+preparatory work for future features/changes.
+
+# Future Changes
+
+- `Str\` HSL functions will start throwing `InvalidArgumentException` instead of
+  `InvariantException` when invalid offsets or lengths are passed. We strongly
+  recommend against catching either of these exceptions.


### PR DESCRIPTION
Quiet release, not much ehre.

There were breaking changes in the nightlies, but they appear to have
all been reverted/disabled.
