### PR TITLE
Add webrick and jekyll-redirect-from to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
 # Uncomment this if you need link redirects from, for example, an old site
 # gem 'jekyll-redirect-from'
+
+gem "webrick", "~> 1.7"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
 # Uncomment this if you need link redirects from, for example, an old site
-# gem 'jekyll-redirect-from'
+gem 'jekyll-redirect-from'
 
 gem "webrick", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,6 +261,7 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
+  jekyll-redirect-from
   webrick (~> 1.7)
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,6 +253,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
+    webrick (1.7.0)
     zeitwerk (2.4.2)
 
 PLATFORMS
@@ -260,6 +261,7 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
+  webrick (~> 1.7)
 
 BUNDLED WITH
-   2.2.16
+   2.2.31

--- a/_config.yml
+++ b/_config.yml
@@ -78,3 +78,6 @@ sass:
 
 redcarpet:
   extensions: [with_toc_data]
+
+plugins:
+  - jekyll-redirect-from


### PR DESCRIPTION
I encountered the error https://github.com/jekyll/jekyll/issues/8523 when I tried to test the site locally.

Add the missing dependency to solve the error.

## Before

```
$ bundle exec jekyll serve
Configuration file: /Users/atry/github/hhvm.com/_config.yml
            Source: /Users/atry/github/hhvm.com
       Destination: /Users/atry/github/hhvm.com/_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
   GitHub Metadata: No GitHub API authentication could be found. Some fields may be missing or have incorrect data.
                    done in 39.471 seconds.
 Auto-regeneration: enabled for '/Users/atry/github/hhvm.com'
bundler: failed to load command: jekyll (/Users/atry/homebrew/lib/ruby/gems/3.0.0/bin/jekyll)
/Users/atry/homebrew/lib/ruby/gems/3.0.0/gems/jekyll-3.9.0/lib/jekyll/commands/serve/servlet.rb:3:in `require': cannot load such file -- webrick (LoadError)
	from /Users/atry/homebrew/lib/ruby/gems/3.0.0/gems/jekyll-3.9.0/lib/jekyll/commands/serve/servlet.rb:3:in `<top (required)>'
	from /Users/atry/homebrew/lib/ruby/gems/3.0.0/gems/jekyll-3.9.0/lib/jekyll/commands/serve.rb:184:in `require_relative'
	from /Users/atry/homebrew/lib/ruby/gems/3.0.0/gems/jekyll-3.9.0/lib/jekyll/commands/serve.rb:184:in `setup'
	from /Users/atry/homebrew/lib/ruby/gems/3.0.0/gems/jekyll-3.9.0/lib/jekyll/commands/serve.rb:102:in `process'
	from /Users/atry/homebrew/lib/ruby/gems/3.0.0/gems/jekyll-3.9.0/lib/jekyll/commands/serve.rb:93:in `block in start'
	from /Users/atry/homebrew/lib/ruby/gems/3.0.0/gems/jekyll-3.9.0/lib/jekyll/commands/serve.rb:93:in `each'
	from /Users/atry/homebrew/lib/ruby/gems/3.0.0/gems/jekyll-3.9.0/lib/jekyll/commands/serve.rb:93:in `start'
	from /Users/atry/homebrew/lib/ruby/gems/3.0.0/gems/jekyll-3.9.0/lib/jekyll/commands/serve.rb:75:in `block (2 levels) in init_with_program'
	from /Users/atry/homebrew/lib/ruby/gems/3.0.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `block in execute'
	from /Users/atry/homebrew/lib/ruby/gems/3.0.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `each'
	from /Users/atry/homebrew/lib/ruby/gems/3.0.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `execute'
	from /Users/atry/homebrew/lib/ruby/gems/3.0.0/gems/mercenary-0.3.6/lib/mercenary/program.rb:42:in `go'
	from /Users/atry/homebrew/lib/ruby/gems/3.0.0/gems/mercenary-0.3.6/lib/mercenary.rb:19:in `program'
	from /Users/atry/homebrew/lib/ruby/gems/3.0.0/gems/jekyll-3.9.0/exe/jekyll:15:in `<top (required)>'
	from /Users/atry/homebrew/lib/ruby/gems/3.0.0/bin/jekyll:23:in `load'
	from /Users/atry/homebrew/lib/ruby/gems/3.0.0/bin/jekyll:23:in `<top (required)>'
	from /Users/atry/homebrew/lib/ruby/gems/3.0.0/gems/bundler-2.2.31/lib/bundler/cli/exec.rb:58:in `load'
	from /Users/atry/homebrew/lib/ruby/gems/3.0.0/gems/bundler-2.2.31/lib/bundler/cli/exec.rb:58:in `kernel_load'
	from /Users/atry/homebrew/lib/ruby/gems/3.0.0/gems/bundler-2.2.31/lib/bundler/cli/exec.rb:23:in `run'
	from /Users/atry/homebrew/lib/ruby/gems/3.0.0/gems/bundler-2.2.31/lib/bundler/cli.rb:478:in `exec'
	from /Users/atry/homebrew/lib/ruby/gems/3.0.0/gems/bundler-2.2.31/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	from /Users/atry/homebrew/lib/ruby/gems/3.0.0/gems/bundler-2.2.31/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from /Users/atry/homebrew/lib/ruby/gems/3.0.0/gems/bundler-2.2.31/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	from /Users/atry/homebrew/lib/ruby/gems/3.0.0/gems/bundler-2.2.31/lib/bundler/cli.rb:31:in `dispatch'
	from /Users/atry/homebrew/lib/ruby/gems/3.0.0/gems/bundler-2.2.31/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	from /Users/atry/homebrew/lib/ruby/gems/3.0.0/gems/bundler-2.2.31/lib/bundler/cli.rb:25:in `start'
	from /Users/atry/homebrew/lib/ruby/gems/3.0.0/gems/bundler-2.2.31/exe/bundle:49:in `block in <top (required)>'
	from /Users/atry/homebrew/lib/ruby/gems/3.0.0/gems/bundler-2.2.31/lib/bundler/friendly_errors.rb:103:in `with_friendly_errors'
	from /Users/atry/homebrew/lib/ruby/gems/3.0.0/gems/bundler-2.2.31/exe/bundle:37:in `<top (required)>'
	from /Users/atry/homebrew/opt/ruby/bin/bundle:23:in `load'
	from /Users/atry/homebrew/opt/ruby/bin/bundle:23:in `<main>'
```
## After

```
$ bundle exec jekyll serve
Configuration file: /Users/atry/github/hhvm.com/_config.yml
            Source: /Users/atry/github/hhvm.com
       Destination: /Users/atry/github/hhvm.com/_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
   GitHub Metadata: No GitHub API authentication could be found. Some fields may be missing or have incorrect data.
                    done in 37.762 seconds.
 Auto-regeneration: enabled for '/Users/atry/github/hhvm.com'
    Server address: http://127.0.0.1:4000
  Server running... press ctrl-c to stop.
      Regenerating: 3 file(s) changed at 2021-11-19 14:24:33
                    _posts/2021-11-08-hhvm-3.135.markdown
                    _posts/2021-11-19-hhvm-4.136.markdown
                    _posts/2021-11-08-hhvm-4.135.markdown
                    ...done in 37.209445 seconds.
```