### PR TITLE
Remove `spl_object_hash` changes from Breaking Changes section

### DIFF
--- a/_posts/2022-08-10-hhvm-4.166.markdown
+++ b/_posts/2022-08-10-hhvm-4.166.markdown
@@ -37,7 +37,6 @@ which should be able to run on any Linux distribution.
   - `<<__Memoize(#MakeICInaccessible)>>`
   - `<<__PolicyShardedMemoize>>`
   - `<<__PolicyShardedMemoizeLSB>>`
-- Mark `spl_object_hash` as taking readonly
 - Make `null` default parameter with non-nullable type hint result in error
 - Always error on nested Expression Trees
 - Lambdas and calls in Expression Trees are now virtualized:


### PR DESCRIPTION
As @lexidor pointed out, it is not a breaking change because `builtins_spl.hhi` has not been updated. Also it is a widening of the signature.