### PR TITLE
Lazy load images on the blog

### DIFF
--- a/_includes/post.html
+++ b/_includes/post.html
@@ -3,7 +3,7 @@
   <header class="post-header">
     {% if author.fbid %}
     <div class="authorPhoto">
-      <img src="https://graph.facebook.com/{{ author.fbid }}/picture/" alt="{{ author.fullname }}" title="{{ author.fullname }}" />
+      <img src="https://graph.facebook.com/{{ author.fbid }}/picture/" alt="{{ author.fullname }}" title="{{ author.fullname }}" loading="lazy" />
     </div>
     {% endif %}
     {% if author.full_name %}

--- a/_posts/2012-09-22-wordpress-3-4-2-running-on-hiphop-hhvm.markdown
+++ b/_posts/2012-09-22-wordpress-3-4-2-running-on-hiphop-hhvm.markdown
@@ -17,7 +17,7 @@ comments:
     or any other path that is set in hhvm.hdf
 ---
 
-![Heated seats](/static/images/posts/dough_burn-300x200.jpg)
+![Heated seats](/static/images/posts/dough_burn-300x200.jpg){:loading="lazy"}
 <center><i>While you wait, here's my sister's cat.</i></center>
 
 Welcome to the inaugural post on the HipHop for PHP blog.  In the coming days, weeks, months, and (dare I predict) years, we'll be creating posts about the inner workings of HipHop, the practical implementation details of running it, and whatever else manages to fit on this site.

--- a/_posts/2014-04-07-debug-packages.markdown
+++ b/_posts/2014-04-07-debug-packages.markdown
@@ -38,7 +38,7 @@ comments:
   content: "Log trace can be found in &#47;tmp with the following format\r\n&#47;tmp&#47;stacktrace..log"
 ---
 
-![](/static/images/posts/1218.png)
+![](/static/images/posts/1218.png){:loading="lazy"}
 
 We try our best to be a stable dependable runtime, but if you are reaching into the deep dark abyss of the PHP language, you might stumble upon a dark corner where we segfault or assert. First of all, we are sorry. Secondly, we would love you to [report the issue](https://github.com/facebook/hhvm/issues), and if you can put together a small test case that is best. If it only reproduces under the full moon when you hold your head to the side and hop on one leg, then a stacktrace would be next best.
 

--- a/_posts/2014-07-30-announcing-a-specification-for-php.markdown
+++ b/_posts/2014-07-30-announcing-a-specification-for-php.markdown
@@ -322,7 +322,7 @@ comments:
   content: "[&#8230;] know I&#8217;m late to the game but this is good [&#8230;]"
 ---
 
-![PHP-logo](/static/images/posts/PHP-logo2.png)
+![PHP-logo](/static/images/posts/PHP-logo2.png){:loading="lazy"}
 
 The PHP language has been around for over 20 years and is clearly one of the most popular programming languages in the world. PHP is definitely the [lingua-franca <del>of the internet</del> for server-side web programming](http://php.net/usage.php).
 

--- a/_posts/2014-10-23-using-xhp-with-bootstrap.markdown
+++ b/_posts/2014-10-23-using-xhp-with-bootstrap.markdown
@@ -40,7 +40,7 @@ comments:
   content: "Excellent. But may be you want to try this other tool:\r\n\r\nhttp:&#47;&#47;codecanyon.net&#47;item&#47;boothelp&#47;11636009"
 ---
 
-![xhpbootstrap_logo_blacktext](/static/images/posts/xhpbootstrap_logo_blacktext.png)
+![xhpbootstrap_logo_blacktext](/static/images/posts/xhpbootstrap_logo_blacktext.png){:loading="lazy"}
 
 [XHP](https://github.com/facebook/xhp) is a great way to safely create HTML user interfaces from PHP or Hack. We love how extensible it is, allowing you to create your own pseudo-elements that are composed of more basic building blocks - ultimately a series of HTML tags. This solves a similar problem to partial templates in other systems. At its most basic level, XHP provides an XML-like syntax for creating stringable objects representing markup:
 

--- a/_posts/2015-02-19-announcing-a-specification-for-hack.markdown
+++ b/_posts/2015-02-19-announcing-a-specification-for-hack.markdown
@@ -65,7 +65,7 @@ comments:
     for the language [&#8230;]"
 ---
 
-![Hack Logo](/static/images/posts/Screenshot-2015-02-18-10.07.47.png)
+![Hack Logo](/static/images/posts/Screenshot-2015-02-18-10.07.47.png){:loading="lazy"}
 
 Today we are excited to announce the availability of the [initial specification for the Hack programming language](https://github.com/hhvm/hack-langspec/blob/master/spec/00-specification-for-hack.md).
 

--- a/_posts/2015-04-23-announcing-our-book-hack-hhvm.markdown
+++ b/_posts/2015-04-23-announcing-our-book-hack-hhvm.markdown
@@ -40,7 +40,7 @@ comments:
     that might be a good read. [&#8230;]"
 ---
 
-![Book cover](/static/images/posts/rc_cat.gif)
+![Book cover](/static/images/posts/rc_cat.gif){:loading="lazy"}
 
 We’d like to get more developers in the community using Hack. But we know there’s been something lacking: a good, consolidated resource for learning Hack and getting the most use out of it. We have documentation online, but it’s more of a reference than a tutorial.
 

--- a/_posts/2015-05-08-hhvm-lockdown.markdown
+++ b/_posts/2015-05-08-hhvm-lockdown.markdown
@@ -107,7 +107,7 @@ comments:
     things are looking overall. Thanks for your interest!"
 ---
 
-![Neon Lockdown Sign](/static/images/posts/10537187_10152729686506660_886816697495269948_o-1.jpg)
+![Neon Lockdown Sign](/static/images/posts/10537187_10152729686506660_886816697495269948_o-1.jpg){:loading="lazy"}
 
 It's that time of year again! Next week the HHVM Open Source team is beginning a lockdown. The next two weeks will feature beards, long hours, and performance wins. We're excited to announce that this will be our first ever open source performance lockdown.
 

--- a/_posts/2018-09-28-hhvm-3.28.2.markdown
+++ b/_posts/2018-09-28-hhvm-3.28.2.markdown
@@ -97,8 +97,8 @@ If a capture group isn't matched in the input string, the value for its key will
 Regular expressions matches are supported by existing IDE features, such as
 type-on-hover and shape key autocomplete:
 
-![type-on-hover example, showing a nullable shape keyed by captures](/static/images/posts/2018-09-28-regex-types.png)
-![shape key autocomplete example, showing autocomplete for named and positional captures](/static/images/posts/2018-09-28-regex-autocomplete.png)
+![type-on-hover example, showing a nullable shape keyed by captures](/static/images/posts/2018-09-28-regex-types.png){:loading="lazy"}
+![shape key autocomplete example, showing autocomplete for named and positional captures](/static/images/posts/2018-09-28-regex-autocomplete.png){:loading="lazy"}
 
 For the full API, see [the source](https://github.com/hhvm/hsl-experimental/blob/03daf701049172f7061d23e76a04197ca1a1be10/src/regex/regex.php); it will join the main HSL documentation once the feature is no longer experimental.
 


### PR DESCRIPTION
The blog contains images in some old blog posts. When visiting the blog for the first time, you don't need to load these images. These images are only needed when you are scrolling to the posts from 2018 and earlier.

For example: _While you wait, here's my sister's cat_ is loaded when the page loads.

I added `loading="lazy"` to all images that load when the blog is visited. Some images only appear in truncated posts, which don't need to be loaded lazily. I left those alone.

All the author images also got the lazy loading treatment. In my opinion, those images are not part of the core content. They used to be pictures of the authors. Nowadays they're default silhouettes. The top author _should ideally_ be loaded eagerly. Loading them lazily doesn't cause a noticeable layout shift, because of the way it is integrated in the page. Open to have my mind changed on this decision.